### PR TITLE
Prepare docker for mac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 from debian:9
 
 RUN apt update
-RUN apt-get -y install git php python3 curl python3-pip gawk
-RUN pip3 install lxml
+RUN apt-get -y install git php python3 curl gawk python3-lxml
 RUN mkdir /Software
 RUN cd /Software && git clone https://github.com/gerw/mathbin
 ENV PATH=$PATH:/Software/mathbin

--- a/README.md
+++ b/README.md
@@ -45,6 +45,6 @@ docker build -t mathbin .
 ```
 from this folder. That creates an image with the name mathbin. Afterwards you can use that image like
 ```
-docker run -rm -v $(pwd):/data mathbin doi2pdf 10.1007/978-1-4612-2972-8
+docker run --rm -v $(pwd):/data mathbin doi2pdf 10.1007/978-1-4612-2972-8
 ```
-The option *-rm* removes the container after downloading the pdf (not the image!), whereas *-v* binds your working directory on the host to the folder /data on the container.
+The option *--rm* removes the container after downloading the pdf (not the image!), whereas *-v* binds your working directory on the host to the folder /data on the container.


### PR DESCRIPTION
Mac runs on ARM, thus the pip3 installation of lxml wants to compile parts from scratch.

It was easier to use the debian packages. Now it seems to work on Apples architecture M1.